### PR TITLE
feat: dynamic learning path inference

### DIFF
--- a/app/routers/curriculum.py
+++ b/app/routers/curriculum.py
@@ -21,6 +21,14 @@ async def get_curriculum():
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch curriculum: {str(e)}")
 
+@router.get("/slug-mapping", summary="Get mapping of URL slugs to path indices")
+async def get_slug_mapping():
+    """Returns a map of { slug: 1-indexed-position } for all learning paths."""
+    try:
+        return curriculum_service.get_slug_to_index_mapping()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to generate mapping: {str(e)}")
+
 @router.get("/learning-path-names", response_model=List[str])
 async def get_learning_path_names(trainer=Depends(require_trainer)):
     """Returns only the names of the learning paths for sidebar navigation."""

--- a/app/services/curriculum_service.py
+++ b/app/services/curriculum_service.py
@@ -501,5 +501,26 @@ def delete_quiz(quiz_id: str):
     if quiz_found:
         save_data(data)
         return {"message": f"Quiz {quiz_id} deleted successfully"}
-        
     raise HTTPException(status_code=404, detail=f"Quiz with ID {quiz_id} not found.")
+
+def get_slug_to_index_mapping():
+    """Returns a map of { slug: 1-indexed-position } for all learning paths AND their pages."""
+    try:
+        data = load_data()
+        mapping = {}
+        for i, card in enumerate(data.get("cards", []), 1):
+            # 1. Map the Learning Path Heading itself
+            heading = card.get("heading", "")
+            path_slug = heading.lower().replace(" ", "-")
+            mapping[path_slug] = i
+            
+            # 2. Map every page (link) within this path
+            # This allows the chatbot to infer the index even from deep-linked pages
+            for link in card.get("links", []):
+                page_text = link.get("text", "")
+                if page_text:
+                    page_slug = page_text.lower().replace(" ", "-")
+                    mapping[page_slug] = i
+        return mapping
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to generate slug mapping: {str(e)}")

--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,18 +1,7 @@
-fix: scheduling engine reliability
+feat: dynamic learning path inference
 
-1. Trainer Availability Refinement
-Model Update (app/models/trainer.py): Changed the default value of is_available from True to False. Trainers now start "Offline," preventing the scheduling engine from assigning doubts to "ghost" accounts.
-Service Layer Alignment (app/services/trainer_service.py): Updated the fallback logic to ensure that if a trainer profile is missing or uninitialized, they default to an "Offline" state.
+Backend Metadata API: Added a new endpoint GET /curriculum/slug-mapping that automatically scans your entire data.json. It maps every single Learning Path Heading and Page Title to its correct 1-indexed position.
 
-2. Identity & Visibility Enhancements
-Schema Update (app/schemas/dashboard.py): Added a trainer_name field to the DashboardOverview response schema.
-Service Logic (app/services/trainer_service.py): Updated the dashboard service to fetch and return the trainer's display name, helping mentors identify which account they are logged into.
-
-3. Scheduling Engine Reliability (Bug Fixes)
-Fixed Session Race Condition (app/routers/trainer.py): Fixed a critical bug where the scheduling engine was failing silently in a background task because the database session was closed before the task could run. Toggling availability now triggers the engine synchronously for guaranteed reliability.
-Improved Observability (app/routers/trainer.py & app/routers/scheduling.py): Removed silent pass blocks and added explicit error logging to the scheduling triggers. If the engine fails to schedule a doubt now, the exact error will be visible in the server logs.
-
-4. Database State Management
-Provided SQL scripts (UPDATE trainers SET is_available = 0 WHERE id > 0;) to synchronize your existing database data with the new "Offline by default" logic.
-
-closes #22
+Benefits:
+- Maintenance-Free: If you rename a path or move a page in data.json, the Chatbot stays in sync automatically.
+- Scalable: It handles hundreds of pages without increasing the frontend bundle size or request overhead.


### PR DESCRIPTION
Backend Metadata API: Added a new endpoint GET /curriculum/slug-mapping that automatically scans your entire data.json. It maps every single Learning Path Heading and Page Title to its correct 1-indexed position.

Benefits:
- Maintenance-Free: If you rename a path or move a page in data.json, the Chatbot stays in sync automatically.
- Scalable: It handles hundreds of pages without increasing the frontend bundle size or request overhead.