### PR TITLE
Fix React Flow depth loop and add responsive mobile manual form and C…

### DIFF
--- a/src/pages/dashboard/trainer/CurriculumManager.js
+++ b/src/pages/dashboard/trainer/CurriculumManager.js
@@ -288,6 +288,23 @@ const QuizTab = ({ pathNames }) => {
     }
   };
 
+  const handleSaveCsvFromModal = async (title, file) => {
+    if (!file || !title || !selectedPath || !selectedTopic) return;
+    try {
+      const formData = new FormData();
+      formData.append('title', title);
+      formData.append('file', file);
+
+      await addQuizCsv(selectedPath, selectedTopic, formData);
+      toast.success("Quiz imported successfully from CSV!");
+      setFlowModalOpen(false);
+      setEditingQuiz(null);
+      fetchQuizzes();
+    } catch (e) {
+      toast.error("Failed to import CSV.");
+    }
+  };
+
   if (loading && quizzes.length === 0) return (
     <div className="flex justify-center items-center py-16">
       <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
@@ -504,6 +521,9 @@ const QuizTab = ({ pathNames }) => {
           onClose={() => setFlowModalOpen(false)}
           initialData={Object.keys(editingQuiz).length > 0 ? editingQuiz : null}
           onSave={handleSaveFlow}
+          selectedPath={selectedPath}
+          selectedTopic={selectedTopic}
+          onSaveCsv={handleSaveCsvFromModal}
         />
       )}
     </div>

--- a/src/pages/dashboard/trainer/QuizFlowModal.js
+++ b/src/pages/dashboard/trainer/QuizFlowModal.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions,
   Button, Box, TextField, Typography, Select, MenuItem,
-  FormControl, InputLabel, IconButton, Alert
+  FormControl, InputLabel, IconButton, Alert, Tabs, Tab
 } from '@mui/material';
 import {
   ReactFlow,
@@ -19,6 +19,8 @@ import '@xyflow/react/dist/style.css';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import InfoIcon from '@mui/icons-material/Info';
+import CloseIcon from '@mui/icons-material/Close';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 
 // Custom Node for Quiz Title
 const QuizNode = ({ data }) => {
@@ -102,10 +104,35 @@ const nodeTypes = {
   questionNode: QuestionNode,
 };
 
-const QuizFlowModal = ({ open, onClose, initialData, onSave }) => {
+const QuizFlowModal = ({ open, onClose, initialData, onSave, selectedPath, selectedTopic, onSaveCsv }) => {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [title, setTitle] = useState('');
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  const [activeTab, setActiveTab] = useState(0);
+  const [mobileCsvFile, setMobileCsvFile] = useState(null);
+
+  // Responsive screen listener
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Sync title changes across state and React Flow root node
+  const handleTitleChange = (newTitle) => {
+    setTitle(newTitle);
+    setNodes((nds) =>
+      nds.map((node) => {
+        if (node.id === 'root') {
+          return { ...node, data: { ...node.data, title: newTitle } };
+        }
+        return node;
+      })
+    );
+  };
 
   // Handle node data changes
   const handleNodeChange = useCallback((id, field, value) => {
@@ -259,6 +286,25 @@ const QuizFlowModal = ({ open, onClose, initialData, onSave }) => {
   };
 
   const handleSave = () => {
+    if (isMobile && activeTab === 1) {
+      if (onSaveCsv && mobileCsvFile) {
+        onSaveCsv(title, mobileCsvFile);
+      }
+      return;
+    }
+
+    if (isMobile) {
+      const questionNodes = nodes.filter(n => n.type === 'questionNode');
+      const orderedQuestions = questionNodes.map((node) => ({
+        id: node.id.replace('q_', ''),
+        text: node.data.text,
+        options: node.data.options,
+        correct_answer: node.data.correct_answer
+      }));
+      onSave({ title, questions: orderedQuestions });
+      return;
+    }
+
     let currentId = 'root';
     const orderedQuestions = [];
     const questionNodesMap = new Map(
@@ -305,59 +351,237 @@ const QuizFlowModal = ({ open, onClose, initialData, onSave }) => {
       open={open}
       onClose={onClose}
       fullWidth maxWidth="lg"
+      fullScreen={isMobile}
       disableEnforceFocus
       disableAutoFocus
       disableRestoreFocus
-      PaperProps={{ sx: { height: '80vh' } }}
+      PaperProps={{ sx: isMobile ? {} : { height: '80vh' } }}
     >
-      <DialogTitle sx={{ fontWeight: 'bold' }}>
-        {initialData ? 'Quiz Flow' : 'Create Quiz Flow'}
+      <DialogTitle sx={{ fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="h6" fontWeight="bold">
+          {initialData ? 'Quiz Flow' : 'Create Quiz Flow'}
+        </Typography>
+        {isMobile && (
+          <IconButton onClick={onClose} edge="end" color="inherit">
+            <CloseIcon />
+          </IconButton>
+        )}
       </DialogTitle>
-      <DialogContent sx={{ p: 0, bgcolor: '#f8fafc' }}>
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          nodeTypes={nodeTypes}
-          fitView
-        >
-          <Background color="#ccc" gap={16} />
-          <Controls />
-          <Panel position="top-center" style={{ marginTop: '10px' }}>
-            <Alert
-              severity="info"
-              icon={<InfoIcon fontSize="small" />}
-              sx={{
-                borderRadius: 2,
-                py: 0.5,
-                px: 2,
-                bgcolor: 'rgba(255, 255, 255, 0.95)',
-                boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
-                border: '1px solid #e0f2fe',
-                '& .MuiAlert-message': { fontSize: '0.875rem', color: '#0369a1' }
-              }}
-            >
-              <strong>Tip:</strong> To reorder questions, select a connecting line and press <strong>Backspace</strong> to delete it.
-            </Alert>
-          </Panel>
-          <Panel position="top-right">
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={addQuestion}
-              sx={{ boxShadow: 2 }}
-            >
-              Add Question
-            </Button>
-          </Panel>
-        </ReactFlow>
+      <DialogContent sx={{ p: isMobile ? 2 : 0, bgcolor: '#f8fafc', display: 'flex', flexDirection: 'column' }}>
+        {isMobile ? (
+          <Box sx={{ flex: 1, overflowY: 'auto' }}>
+            {!initialData && (
+              <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+                <Tabs value={activeTab} onChange={(e, val) => setActiveTab(val)} variant="fullWidth">
+                  <Tab label="Form Editor" />
+                  <Tab label="CSV Upload" />
+                </Tabs>
+              </Box>
+            )}
+
+            {activeTab === 0 ? (
+              // Form Editor Mode
+              <Box>
+                <TextField
+                  label="Quiz Title"
+                  variant="outlined"
+                  fullWidth
+                  value={title}
+                  onChange={(e) => handleTitleChange(e.target.value)}
+                  sx={{ mb: 3, bgcolor: '#fff' }}
+                />
+
+                <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1.5, color: '#475569' }}>
+                  Questions ({nodes.filter(n => n.type === 'questionNode').length})
+                </Typography>
+
+                {nodes.filter(n => n.type === 'questionNode').map((node, index) => (
+                  <Box
+                    key={node.id}
+                    sx={{
+                      bgcolor: '#fff',
+                      p: 2.5,
+                      mb: 2.5,
+                      borderRadius: '12px',
+                      border: '1px solid #cbd5e1',
+                      boxShadow: '0 2px 4px rgba(0,0,0,0.02)'
+                    }}
+                  >
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                      <Typography variant="subtitle2" fontWeight="bold" color="primary">
+                        Question {index + 1}
+                      </Typography>
+                      <IconButton size="small" color="error" onClick={() => handleDeleteNode(node.id)}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+
+                    <TextField
+                      label="Question Text"
+                      size="small"
+                      fullWidth
+                      multiline
+                      rows={2}
+                      value={node.data.text || ''}
+                      onChange={(e) => handleNodeChange(node.id, 'text', e.target.value)}
+                      sx={{ mb: 2 }}
+                    />
+
+                    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 1.5, mb: 2 }}>
+                      {[0, 1, 2, 3].map((optIdx) => (
+                        <TextField
+                          key={optIdx}
+                          label={`Option ${optIdx + 1}`}
+                          size="small"
+                          fullWidth
+                          value={node.data.options[optIdx] || ''}
+                          onChange={(e) => handleNodeChange(node.id, `option${optIdx}`, e.target.value)}
+                        />
+                      ))}
+                    </Box>
+
+                    <FormControl fullWidth size="small">
+                      <InputLabel>Correct Answer</InputLabel>
+                      <Select
+                        value={node.data.correct_answer || ''}
+                        label="Correct Answer"
+                        onChange={(e) => handleNodeChange(node.id, 'correct_answer', e.target.value)}
+                      >
+                        {node.data.options.map((opt, i) => (
+                          <MenuItem key={i} value={opt} disabled={!opt}>
+                            {opt || `Option ${i + 1}`}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Box>
+                ))}
+
+                <Button
+                  variant="outlined"
+                  fullWidth
+                  startIcon={<AddIcon />}
+                  onClick={addQuestion}
+                  sx={{
+                    mt: 1,
+                    mb: 4,
+                    py: 1.5,
+                    borderStyle: 'dashed',
+                    borderColor: 'primary.main',
+                    color: 'primary.main',
+                    '&:hover': {
+                      borderStyle: 'dashed',
+                      bgcolor: 'rgba(59, 130, 246, 0.04)'
+                    }
+                  }}
+                >
+                  Add Question
+                </Button>
+              </Box>
+            ) : (
+              // CSV Upload Mode
+              <Box>
+                <TextField
+                  label="Quiz Title"
+                  variant="outlined"
+                  fullWidth
+                  value={title}
+                  onChange={(e) => handleTitleChange(e.target.value)}
+                  sx={{ mb: 3, bgcolor: '#fff' }}
+                />
+
+                <Box
+                  onClick={() => document.getElementById('mobile-csv-file-input').click()}
+                  sx={{
+                    border: '2px dashed #cbd5e1',
+                    borderRadius: '12px',
+                    p: 4,
+                    textAlign: 'center',
+                    cursor: 'pointer',
+                    bgcolor: '#fff',
+                    transition: 'all 0.2s',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      bgcolor: 'rgba(59, 130, 246, 0.02)'
+                    }
+                  }}
+                >
+                  <input
+                    type="file"
+                    id="mobile-csv-file-input"
+                    accept=".csv"
+                    style={{ display: 'none' }}
+                    onChange={(e) => setMobileCsvFile(e.target.files[0])}
+                  />
+                  <CloudUploadIcon sx={{ fontSize: 48, color: '#94a3b8', mb: 1 }} />
+                  <Typography variant="subtitle1" fontWeight="bold">
+                    {mobileCsvFile ? mobileCsvFile.name : 'Select CSV File'}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                    {mobileCsvFile ? `${(mobileCsvFile.size / 1024).toFixed(2)} KB` : 'Click to browse and upload your quiz CSV'}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+          </Box>
+        ) : (
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            nodeTypes={nodeTypes}
+            onInit={(instance) => {
+              setTimeout(() => {
+                instance.fitView({ padding: 0.2 });
+              }, 150);
+            }}
+          >
+            <Background color="#ccc" gap={16} />
+            <Controls />
+            <Panel position="top-center" style={{ marginTop: '10px' }}>
+              <Alert
+                severity="info"
+                icon={<InfoIcon fontSize="small" />}
+                sx={{
+                  borderRadius: 2,
+                  py: 0.5,
+                  px: 2,
+                  bgcolor: 'rgba(255, 255, 255, 0.95)',
+                  boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+                  border: '1px solid #e0f2fe',
+                  '& .MuiAlert-message': { fontSize: '0.875rem', color: '#0369a1' }
+                }}
+              >
+                <strong>Tip:</strong> To reorder questions, select a connecting line and press <strong>Backspace</strong> to delete it.
+              </Alert>
+            </Panel>
+            <Panel position="top-right">
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={addQuestion}
+                sx={{ boxShadow: 2 }}
+              >
+                Add Question
+              </Button>
+            </Panel>
+          </ReactFlow>
+        )}
       </DialogContent>
-      <DialogActions sx={{ p: 2, bgcolor: '#fff' }}>
+      <DialogActions sx={{ p: 2, bgcolor: '#fff', borderTop: '1px solid #e2e8f0' }}>
         <Button onClick={onClose} color="inherit">Cancel</Button>
-        <Button onClick={handleSave} variant="contained" disabled={!title || nodes.length <= 1}>
-          Save Quiz
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={
+            isMobile && activeTab === 1
+              ? !title || !mobileCsvFile
+              : !title || nodes.filter(n => n.type === 'questionNode').length === 0
+          }
+        >
+          {isMobile && activeTab === 1 ? 'Import Quiz' : 'Save Quiz'}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
**Built Responsive Mobile View (Form & CSV Upload)**

Introduced screen size checks to dynamically transition the modal to fullscreen layout under mobile viewports (< 768px).
Restructured the mobile Dialog to support tabs:
Form Editor: Input field for Quiz Title, followed by clean scrollable cards for each question (Question text textarea, 4 option textfields, correct answer selector select dropdown, and a delete button), and an "+ Add Question" button at the bottom.
CSV Upload: Title input and a customized drag-and-drop/clickable file uploader zone.
Rewrote the saving logic under mobile viewports to package form state directly or delegate to custom CSV saving handlers.


**Integrated parent callbacks**

Updated  CurriculumManager.js  to pass selectedPath and selectedTopic to <QuizFlowModal>.
Handled mobile CSV uploads directly from the flow editor modal via the newly created handleSaveCsvFromModal API connector.

partial solution for #18 