### PR TITLE
feat: implement chevron progress tracker for multiple exercises

### DIFF
--- a/src/components/common/ChevronTracker.css
+++ b/src/components/common/ChevronTracker.css
@@ -1,0 +1,86 @@
+.chevron-tracker-scroll-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  padding: 10px 0;
+  margin-bottom: 20px;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.chevron-tracker-scroll-wrapper::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.chevron-tracker-scroll-wrapper {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
+.chevron-tracker {
+  display: flex;
+  align-items: center;
+  min-width: max-content; 
+  padding-left: 2px;
+}
+
+.chevron-tab {
+  width: 75px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 15px;
+  transition: all 0.2s ease;
+  clip-path: polygon(0% 0%, 80% 0%, 100% 50%, 80% 100%, 0% 100%, 20% 50%);
+  margin-left: -15px; 
+  padding-left: 10px; 
+  outline: none;
+}
+
+.chevron-tab:first-child {
+  margin-left: 0;
+  clip-path: polygon(0% 0%, 80% 0%, 100% 50%, 80% 100%, 0% 100%);
+  padding-left: 0; 
+}
+
+.chevron-tab:focus {
+  outline: none;
+}
+
+/* States */
+.chevron-tab.pending {
+  background-color: #e2e8f0;
+  color: #475569;
+}
+
+.chevron-tab.pending:hover {
+  background-color: #cbd5e1;
+}
+
+.chevron-tab.active {
+  background-color: #4361ee;
+  color: #ffffff;
+  z-index: 10; 
+}
+
+.chevron-tab.active:hover {
+  background-color: #3753d7;
+}
+
+.chevron-tab.completed {
+  background-color: #10b981;
+  color: #ffffff;
+}
+
+.chevron-tab.completed:hover {
+  background-color: #059669;
+}
+
+.chevron-number {
+  position: relative;
+  z-index: 2;
+}

--- a/src/components/common/ChevronTracker.js
+++ b/src/components/common/ChevronTracker.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import './ChevronTracker.css';
+
+function ChevronTracker({ exercises, activeExerciseIndex, setActiveExerciseIndex, isExerciseSolved }) {
+  if (!exercises || exercises.length <= 1) return null;
+
+  return (
+    <div className="chevron-tracker-scroll-wrapper">
+      <div className="chevron-tracker">
+        {exercises.map((ex, index) => {
+          const solved = isExerciseSolved(ex.id);
+          const active = index === activeExerciseIndex;
+          
+          let statusClass = 'pending';
+          if (active) {
+            statusClass = 'active';
+          } else if (solved) {
+            statusClass = 'completed';
+          }
+
+          return (
+            <button
+              key={ex.id || index}
+              className={`chevron-tab ${statusClass}`}
+              onClick={() => setActiveExerciseIndex(index)}
+              title={ex.title}
+            >
+              <span className="chevron-number">{index + 1}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default ChevronTracker;

--- a/src/pages/LearningPathTopic.js
+++ b/src/pages/LearningPathTopic.js
@@ -8,6 +8,7 @@ import { useProgress, useTopicStatus } from '../hooks/useProgress';
 import ExerciseCompiler from '../components/common/ExerciseCompiler';
 import Quiz from '../components/common/Quiz';
 import VideoCarousel from '../components/common/VideoCarousel';
+import ChevronTracker from '../components/common/ChevronTracker';
 import Compiler from './compiler';
 
 // Scoped styles
@@ -80,6 +81,11 @@ function LearningPathTopic() {
   const [showCompiler, setShowCompiler] = useState(false);
   const [copiedId, setCopiedId] = useState(null);
   const [solvingExercise, setSolvingExercise] = useState(null);
+  const [activeExerciseIndex, setActiveExerciseIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveExerciseIndex(0);
+  }, [topicId]);
 
   const {
     markTheoryRead,
@@ -419,10 +425,22 @@ function LearningPathTopic() {
                       <div className="exercises-section">
                         <h3 className="exercise-heading">⚡ Hands-on Challenges</h3>
                         <div className="section-divider"></div>
-                        {content.exercises.map((ex, i) => {
+                        
+                        {content.exercises.length > 1 && (
+                          <ChevronTracker
+                            exercises={content.exercises}
+                            activeExerciseIndex={activeExerciseIndex}
+                            setActiveExerciseIndex={setActiveExerciseIndex}
+                            isExerciseSolved={(id) => !!(topicStatus?.exercises?.[id] || exerciseProgress[id]?.status === 'completed')}
+                          />
+                        )}
+
+                        {(() => {
+                          const ex = content.exercises.length === 1 ? content.exercises[0] : content.exercises[activeExerciseIndex];
+                          if (!ex) return null;
                           const isSolved = topicStatus?.exercises?.[ex.id] || exerciseProgress[ex.id]?.status === 'completed';
                           return (
-                            <div key={ex.id || i} className="exercise-card">
+                            <div className="exercise-card">
                               <div className="exercise-badge">{ex.difficulty}</div>
                               <h4>{ex.title}</h4>
                               <p>{ex.description}</p>
@@ -439,7 +457,7 @@ function LearningPathTopic() {
                               </div>
                             </div>
                           );
-                        })}
+                        })()}
                       </div>
                     )}
 


### PR DESCRIPTION
This PR addresses the UI/UX issue where topics with multiple assigned exercises were being stacked vertically, leading to massive vertical space consumption and a degraded user experience. 

It introduces a brand new **Chevron Progress Tracker** (breadcrumb-style numbered tab interface) that cleanly manages navigation between multiple exercises, ensuring that only one active exercise card is visible at a time.

## Key Changes
- **New `ChevronTracker.js` Component:** Built a dynamic tracking component that maps through available exercises.
- **Dynamic Styling (`ChevronTracker.css`):**
  - Utilizes CSS `clip-path` and negative margins for seamless chevron overlapping.
  - Horizontally swipeable layout for mobile screens (with hidden scrollbars).
  - Fully integrates the JS-Mentor brand color palette (Brand Blue for active, Success Green for solved, Light Gray for pending).
- **`LearningPathTopic.js` Integration:** 
  - Conditionally mounts the Chevron Tracker only if `exercises.length > 1`.
  - Degrades gracefully to the original single-card view for topics with only one challenge.
  - Manages active tab state locally and auto-resets when switching between learning path topics.